### PR TITLE
Feature/fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -32,8 +32,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-            echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Composer Cache
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Composer Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
             path: ${{ steps.composer-cache.outputs.dir }}
             key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Code Coverage Report
         if: success() && matrix.php-version == '8.1'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
             file: ./tests/_output/coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,7 @@ jobs:
         run: composer stan
 
       - name: Run tests
-        run: |
-          vendor/bin/codecept build
-          vendor/bin/codecept run --coverage-xml
+        run: vendor/bin/codecept run --coverage-xml
 
       - name: Code Coverage Report
         if: success() && matrix.php-version == '8.1'

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "spryker/development": "^3.32.1",
         "phpunit/phpunit": "^9.5.0 || ^10.0.0",
         "spryker/testify": "^3.49.0",
-        "spryker-sdk/phpstan-spryker": "^0.4.0"
+        "spryker-sdk/phpstan-spryker": "^0.4.0",
+        "galbar/jsonpath": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,17 @@
             "SprykerConfig\\": "src/SprykerConfig/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "PyzTest\\": [
+                "tests/PyzTest/",
+                "tests/_support"
+            ]
+        },
+        "files": [
+            "test-autoload.php"
+        ]
+    },
     "scripts": {
         "cs-check": "phpcs -p",
         "cs-fix": "phpcbf -p",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c23f11c91c93006d5471cea44b038a5",
+    "content-hash": "ae82150ac8321dd03c4da974e1560837",
     "packages": [
         {
             "name": "brick/math",
@@ -10896,6 +10896,57 @@
                 "source": "https://github.com/FakerPHP/Faker/tree/v1.23.0"
             },
             "time": "2023-06-12T08:44:38+00:00"
+        },
+        {
+            "name": "galbar/jsonpath",
+            "version": "3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Galbar/JsonPath-PHP.git",
+                "reference": "61bfdd51729ac95413aaf64112b93b6fb3dbd786"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Galbar/JsonPath-PHP/zipball/61bfdd51729ac95413aaf64112b93b6fb3dbd786",
+                "reference": "61bfdd51729ac95413aaf64112b93b6fb3dbd786",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "sami/sami": ">=3.3.0",
+                "satooshi/php-coveralls": ">=1.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JsonPath\\": "src/Galbar/JsonPath",
+                    "Utilities\\": "src/Galbar/Utilities"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alessio Linares",
+                    "email": "alessio@alessio.cc"
+                }
+            ],
+            "description": "JSONPath implementation for querying and updating JSON objects",
+            "keywords": [
+                "json",
+                "jsonpath",
+                "path"
+            ],
+            "support": {
+                "issues": "https://github.com/Galbar/JsonPath-PHP/issues",
+                "source": "https://github.com/Galbar/JsonPath-PHP/tree/3.0"
+            },
+            "time": "2023-03-05T19:47:06+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -8,6 +8,7 @@ use Spryker\Shared\Application\Log\Config\SprykerLoggerConfig;
 use Spryker\Shared\ErrorHandler\ErrorHandlerConstants;
 use Spryker\Shared\ErrorHandler\ErrorRenderer\WebHtmlErrorRenderer;
 use Spryker\Shared\GlueBackendApiApplication\GlueBackendApiApplicationConstants;
+use Spryker\Shared\GlueJsonApiConvention\GlueJsonApiConventionConstants;
 use Spryker\Shared\Kernel\KernelConstants;
 use Spryker\Shared\Log\LogConstants;
 use Spryker\Shared\Monitoring\MonitoringConstants;
@@ -126,7 +127,24 @@ $config[LogConstants::EXCEPTION_LOG_FILE_PATH_ZED]
 // ----------------------------------------------------------------------------
 // ------------------------------ Glue Backend API ----------------------------
 // ----------------------------------------------------------------------------
-$config[GlueBackendApiApplicationConstants::GLUE_BACKEND_API_HOST] = getenv('SPRYKER_GLUE_BACKEND_HOST');
+$sprykerGlueBackendHost = getenv('SPRYKER_GLUE_BACKEND_HOST');
+$config[GlueBackendApiApplicationConstants::GLUE_BACKEND_API_HOST] = $sprykerGlueBackendHost;
+$config[GlueBackendApiApplicationConstants::PROJECT_NAMESPACES] = [
+    'Pyz',
+];
+$config[GlueBackendApiApplicationConstants::GLUE_BACKEND_CORS_ALLOW_ORIGIN] = getenv('SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN') ?: '*';
+
+// ----------------------------------------------------------------------------
+// ------------------------------ Glue Storefront API -------------------------
+// ----------------------------------------------------------------------------
+$sprykerGlueStorefrontHost = getenv('SPRYKER_GLUE_STOREFRONT_HOST');
+$gluePort = (int)(getenv('SPRYKER_API_PORT')) ?: 443;
+$protocol = $gluePort === 433 ? 'https' : 'http';
+$config[GlueJsonApiConventionConstants::GLUE_DOMAIN] = sprintf(
+    '%s://%s',
+    $protocol,
+    $sprykerGlueStorefrontHost ?: $sprykerGlueBackendHost ?: 'localhost',
+);
 
 // ----------------------------------------------------------------------------
 // ------------------------------ Scheduler -----------------------------------

--- a/config/install/development.yml
+++ b/config/install/development.yml
@@ -59,6 +59,9 @@ sections:
         generate-service-backend-ide-auto-completion:
             command: 'vendor/bin/console dev:ide-auto-completion:service:generate'
 
+        codeception-build:
+            command: 'vendor/bin/codecept build'
+
     database-flush:
 #        drop-database:
 #            command: 'vendor/bin/console propel:database:drop'

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
         All sniffs in ./Sniffs will be auto loaded
     </description>
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80000"/>
 
     <file>src/</file>
     <file>config/</file>
@@ -29,12 +29,5 @@
     </rule>
 
     <!-- Define your own sniffs here -->
-
-    <rule ref="Spryker.Internal.SprykerDisallowFunctions">
-        <properties>
-            <!-- We want to prevent 8.0+ functions to break 7.4 compatibility -->
-            <property name="phpVersion" value="7.4"/>
-        </properties>
-    </rule>
 
 </ruleset>

--- a/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -9,6 +9,7 @@ namespace Pyz\Zed\Console;
 
 use Spryker\Zed\Cache\Communication\Console\EmptyAllCachesConsole;
 use Spryker\Zed\Console\ConsoleDependencyProvider as SprykerConsoleDependencyProvider;
+use Spryker\Zed\Development\Communication\Console\CodeStyleSnifferConsole;
 use Spryker\Zed\Development\Communication\Console\GenerateClientIdeAutoCompletionConsole;
 use Spryker\Zed\Development\Communication\Console\GenerateGlueBackendIdeAutoCompletionConsole;
 use Spryker\Zed\Development\Communication\Console\GenerateIdeAutoCompletionConsole;
@@ -89,6 +90,7 @@ class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
         $commands = array_merge($commands, $propelCommands);
 
         if ($this->getConfig()->isDevelopmentConsoleCommandsEnabled()) {
+            $commands[] = new CodeStyleSnifferConsole();
             $commands[] = new ValidatorConsole();
             $commands[] = new DataBuilderGeneratorConsole();
             $commands[] = new RemoveDataBuilderConsole();

--- a/tests/PyzTest/Glue/Testify/_support/Helper/GlueBackendApiHelper.php
+++ b/tests/PyzTest/Glue/Testify/_support/Helper/GlueBackendApiHelper.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace PyzTest\Glue\Testify\Helper;
+
+use Codeception\Stub;
+use Pyz\Glue\GlueApplication\Bootstrap\GlueBackendApiBootstrap;
+use Pyz\Glue\GlueApplication\GlueApplicationDependencyProvider;
+use Spryker\Glue\GlueApplication\GlueApplicationFactory;
+use Spryker\Glue\Kernel\Container;
+use Spryker\Shared\Application\ApplicationInterface;
+use SprykerTest\Glue\Testify\Helper\GlueBackendApiHelper as SprykerGlueBackendApiHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GlueBackendApiHelper extends SprykerGlueBackendApiHelper
+{
+    /**
+     * @param string $url
+     * @param string $method
+     * @param array<mixed, mixed> $parameters
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function executeRequest(string $url, string $method, array $parameters = []): Response
+    {
+        $request = Request::create($url, $method, $parameters, [], [], [], $parameters ? json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR) : null);
+
+        $request->headers->add($this->headers);
+
+        // Set the predefined Request so that the GlueBackendApiApplication can pick it up instead of creating an empty Request.
+        $this->getRequestBuilderStub()->setRequest($request);
+
+        // Run the mocked GlueBackendApiApplication.
+        $this->getGlueBackendApiApplication()->run();
+
+        // Get the response that was created from the GlueBackendApiApplication.
+        $response = $this->getHttpSenderStub()->getResponse();
+
+        $this->persistLastConnection($request, $response);
+
+        return $response;
+    }
+
+    /**
+     * @return \Spryker\Shared\Application\ApplicationInterface
+     */
+    protected function getGlueBackendApiApplication(): ApplicationInterface
+    {
+        /** @var \Spryker\Glue\GlueApplication\GlueApplicationFactory $glueApplicationFactory */
+        $glueApplicationFactory = Stub::make(GlueApplicationFactory::class, [
+            'createHttpRequestBuilder' => $this->getRequestBuilderStub(),
+            'createHttpSender' => $this->getHttpSenderStub(),
+            'getConfig' => $this->getConfigHelper()->getModuleConfig('GlueApplication'),
+        ]);
+
+        $glueApplicationDependencyProvider = new GlueApplicationDependencyProvider();
+        $glueApplicationFactory->setContainer(
+            $glueApplicationDependencyProvider->provideDependencies(new Container()),
+        );
+
+        return (new GlueBackendApiBootstrap())
+            ->setFactory($glueApplicationFactory)
+            ->boot();
+    }
+
+    /**
+     * Overridden to not throw an exception when we are on project level and do not need to set plugins manually.
+     *
+     * @return array<\Spryker\Glue\GlueJsonApiConventionExtension\Dependency\Plugin\JsonApiResourceInterface>
+     */
+    protected function getJsonApiResourcePlugins(): array
+    {
+        if (count($this->jsonApiResourcePlugins) === 0) {
+            return [];
+        }
+
+        return $this->jsonApiResourcePlugins;
+    }
+}


### PR DESCRIPTION
- Fixed deprecation warning in CI `The following actions uses node12 which is deprecated`
- Added missing Glue Domain configuration, which is required for formatting links for the response.
- Added CodeStyleSnifferConsole.
