### PR TITLE
Remove preferred-install section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,14 +76,6 @@
         "platform": {
             "php": "8.0.19"
         },
-        "preferred-install": {
-            "spryker/*": "source",
-            "spryker-shop/*": "source",
-            "spryker-eco/*": "source",
-            "spryker-middleware/*": "source",
-            "spryker-sdk/*": "source",
-            "*": "dist"
-        },
         "use-include-path": true,
         "process-timeout": 1800,
         "chromium-revision": 814168,


### PR DESCRIPTION
Composer cannot parallelize downloads of packages that needs to be downloaded from source.

The mini framework is not intended to be used for development on most Spryker packages/modules. It can still be easily attained for individual packages by specifying a branch in the individual requirements (e.g. `dev-main`).

```
rm -rf vendor/ && time composer install --no-cache --prefer-dist
real	0m18.448s
user	0m7.668s
sys	0m5.800s
```

Timing when using settings as-is
```
rm -rf vendor/ && time composer install --no-cache
real	3m56.182s
user	1m15.745s
sys	0m23.988s
```